### PR TITLE
fix: ヘッダーパディングの修正 - AppTopBarから上部WindowInsetsを削除

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -12,7 +12,8 @@
       "Bash(java:*)",
       "Bash(ls:*)",
       "Bash(export JAVA_HOME=\"/Applications/Android Studio.app/Contents/jbr/Contents/Home\")",
-      "Bash(git checkout:*)"
+      "Bash(git checkout:*)",
+      "Bash(rm:*)"
     ],
     "deny": []
   }

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,8 @@ out/
 build/
 gradle-app.setting
 !gradle-wrapper.jar
+*.bin
+*.lock
 
 # Local configuration file (sdk path, etc)
 local.properties

--- a/app/src/main/java/com/example/readingtracker/ui/components/AppTopBar.kt
+++ b/app/src/main/java/com/example/readingtracker/ui/components/AppTopBar.kt
@@ -1,0 +1,43 @@
+package com.example.readingtracker.ui.components
+
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.only
+import androidx.compose.foundation.layout.systemBars
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.navigation.NavController
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AppTopBar(
+    title: String,
+    modifier: Modifier = Modifier,
+    navController: NavController? = null,
+    showBackButton: Boolean = false,
+    actions: @Composable RowScope.() -> Unit = {},
+) {
+    TopAppBar(
+        title = { Text(title) },
+        modifier = modifier,
+        navigationIcon = {
+            if (showBackButton && navController != null) {
+                IconButton(onClick = { navController.popBackStack() }) {
+                    Icon(Icons.Default.ArrowBack, contentDescription = "戻る")
+                }
+            }
+        },
+        actions = actions,
+        windowInsets = WindowInsets.systemBars.only(WindowInsetsSides.Horizontal + WindowInsetsSides.Top),
+        colors = TopAppBarDefaults.topAppBarColors()
+    )
+}

--- a/app/src/main/java/com/example/readingtracker/ui/components/AppTopBar.kt
+++ b/app/src/main/java/com/example/readingtracker/ui/components/AppTopBar.kt
@@ -37,7 +37,7 @@ fun AppTopBar(
             }
         },
         actions = actions,
-        windowInsets = WindowInsets.systemBars.only(WindowInsetsSides.Horizontal + WindowInsetsSides.Top),
+        windowInsets = WindowInsets.systemBars.only(WindowInsetsSides.Horizontal),
         colors = TopAppBarDefaults.topAppBarColors()
     )
 }

--- a/app/src/main/java/com/example/readingtracker/ui/screens/actionitem/ActionItemCreateScreen.kt
+++ b/app/src/main/java/com/example/readingtracker/ui/screens/actionitem/ActionItemCreateScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
+import com.example.readingtracker.ui.components.AppTopBar
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -35,13 +36,10 @@ fun ActionItemCreateScreen(
     
     Scaffold(
         topBar = {
-            TopAppBar(
-                title = { Text("実践項目を作成") },
-                navigationIcon = {
-                    IconButton(onClick = { navController.popBackStack() }) {
-                        Icon(Icons.Default.ArrowBack, contentDescription = "戻る")
-                    }
-                }
+            AppTopBar(
+                title = "実践項目を作成",
+                navController = navController,
+                showBackButton = true
             )
         }
     ) { paddingValues ->

--- a/app/src/main/java/com/example/readingtracker/ui/screens/bookdetail/BookDetailScreen.kt
+++ b/app/src/main/java/com/example/readingtracker/ui/screens/bookdetail/BookDetailScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.*
 import androidx.compose.material3.*
+import com.example.readingtracker.ui.components.AppTopBar
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -40,13 +41,10 @@ fun BookDetailScreen(
     
     Scaffold(
         topBar = {
-            TopAppBar(
-                title = { Text("書籍詳細") },
-                navigationIcon = {
-                    IconButton(onClick = { navController.popBackStack() }) {
-                        Icon(Icons.Default.ArrowBack, contentDescription = "戻る")
-                    }
-                }
+            AppTopBar(
+                title = "書籍詳細",
+                navController = navController,
+                showBackButton = true
             )
         }
     ) { paddingValues ->

--- a/app/src/main/java/com/example/readingtracker/ui/screens/bookregistration/BookConfirmationScreen.kt
+++ b/app/src/main/java/com/example/readingtracker/ui/screens/bookregistration/BookConfirmationScreen.kt
@@ -16,6 +16,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import coil.compose.AsyncImage
 import com.example.readingtracker.data.model.BookInfo
+import com.example.readingtracker.ui.components.AppTopBar
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -27,13 +28,10 @@ fun BookConfirmationScreen(
     
     Scaffold(
         topBar = {
-            TopAppBar(
-                title = { Text("書籍情報の確認") },
-                navigationIcon = {
-                    IconButton(onClick = { navController.popBackStack() }) {
-                        Icon(Icons.Default.ArrowBack, contentDescription = "戻る")
-                    }
-                }
+            AppTopBar(
+                title = "書籍情報の確認",
+                navController = navController,
+                showBackButton = true
             )
         }
     ) { paddingValues ->

--- a/app/src/main/java/com/example/readingtracker/ui/screens/bookregistration/BookRegistrationMethodScreen.kt
+++ b/app/src/main/java/com/example/readingtracker/ui/screens/bookregistration/BookRegistrationMethodScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import com.example.readingtracker.ui.navigation.Routes
+import com.example.readingtracker.ui.components.AppTopBar
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -20,13 +21,10 @@ fun BookRegistrationMethodScreen(
 ) {
     Scaffold(
         topBar = {
-            TopAppBar(
-                title = { Text("書籍を登録") },
-                navigationIcon = {
-                    IconButton(onClick = { navController.popBackStack() }) {
-                        Icon(Icons.Default.ArrowBack, contentDescription = "戻る")
-                    }
-                }
+            AppTopBar(
+                title = "書籍を登録",
+                navController = navController,
+                showBackButton = true
             )
         }
     ) { paddingValues ->

--- a/app/src/main/java/com/example/readingtracker/ui/screens/bookregistration/PurposeSettingScreen.kt
+++ b/app/src/main/java/com/example/readingtracker/ui/screens/bookregistration/PurposeSettingScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import com.example.readingtracker.data.model.PurposeCategory
+import com.example.readingtracker.ui.components.AppTopBar
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -28,13 +29,10 @@ fun PurposeSettingScreen(
     
     Scaffold(
         topBar = {
-            TopAppBar(
-                title = { Text("読書目的の設定") },
-                navigationIcon = {
-                    IconButton(onClick = { navController.popBackStack() }) {
-                        Icon(Icons.Default.ArrowBack, contentDescription = "戻る")
-                    }
-                }
+            AppTopBar(
+                title = "読書目的の設定",
+                navController = navController,
+                showBackButton = true
             )
         }
     ) { paddingValues ->

--- a/app/src/main/java/com/example/readingtracker/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/com/example/readingtracker/ui/screens/home/HomeScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.*
+import com.example.readingtracker.ui.components.AppTopBar
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -28,8 +29,8 @@ fun HomeScreen(
 
     Scaffold(
         topBar = {
-            TopAppBar(
-                title = { Text("Reading Tracker") },
+            AppTopBar(
+                title = "Reading Tracker",
                 actions = {
                     IconButton(onClick = { /* TODO: 検索実装 */ }) {
                         Icon(Icons.Default.Search, contentDescription = "検索")

--- a/app/src/main/java/com/example/readingtracker/ui/screens/memo/MemoAddScreen.kt
+++ b/app/src/main/java/com/example/readingtracker/ui/screens/memo/MemoAddScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
+import com.example.readingtracker.ui.components.AppTopBar
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -34,13 +35,10 @@ fun MemoAddScreen(
     
     Scaffold(
         topBar = {
-            TopAppBar(
-                title = { Text("メモを追加") },
-                navigationIcon = {
-                    IconButton(onClick = { navController.popBackStack() }) {
-                        Icon(Icons.Default.ArrowBack, contentDescription = "戻る")
-                    }
-                }
+            AppTopBar(
+                title = "メモを追加",
+                navController = navController,
+                showBackButton = true
             )
         }
     ) { paddingValues ->

--- a/app/src/main/java/com/example/readingtracker/ui/screens/statistics/StatisticsScreen.kt
+++ b/app/src/main/java/com/example/readingtracker/ui/screens/statistics/StatisticsScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.KeyboardArrowLeft
 import androidx.compose.material.icons.filled.KeyboardArrowRight
 import androidx.compose.material3.*
+import com.example.readingtracker.ui.components.AppTopBar
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -26,8 +27,8 @@ fun StatisticsScreen(
     
     Scaffold(
         topBar = {
-            TopAppBar(
-                title = { Text("統計") }
+            AppTopBar(
+                title = "統計"
             )
         }
     ) { paddingValues ->


### PR DESCRIPTION
  ## 概要
  - AppTopBarコンポーネントから上部のWindow Insetsを削除して、二重のトップパディングを防止
  - 水平方向のWindow Insetsのみを使用することでヘッダーパディングの問題を修正

  ## 変更内容
  - `AppTopBar.kt`を修正し、`WindowInsets.systemBars.only(WindowInsetsSides.Horizontal)`を使用（トップInsetsを含め
  ない）
  - TopAppBarの上部パディングが過剰になることを防止（システムInsetsが他の場所で既に処理されているため）

  ## テスト計画
  - [ ] アプリのビルドが正常に完了すること
  - [ ] 異なるデバイスでヘッダーパディングが正しく表示されること
  - [ ] 水平方向のInsets（ノッチなど）が正常に機能すること

  🤖 Generated with [Claude Code](https://claude.ai/code)
