### PR TITLE
カメラ起動時はフッターナビゲーションを非表示にする

### DIFF
--- a/app/src/main/java/com/example/readingtracker/ui/ReadingTrackerApp.kt
+++ b/app/src/main/java/com/example/readingtracker/ui/ReadingTrackerApp.kt
@@ -11,6 +11,7 @@ import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import com.example.readingtracker.ui.navigation.AppNavigation
+import com.example.readingtracker.ui.navigation.Routes
 import com.example.readingtracker.ui.navigation.bottomNavItems
 
 @Composable
@@ -18,26 +19,51 @@ fun ReadingTrackerApp() {
     val navController = rememberNavController()
     val navBackStackEntry by navController.currentBackStackEntryAsState()
     val currentDestination = navBackStackEntry?.destination
+    
+    // フッターナビゲーションを非表示にする画面のリスト
+    val routesWithoutBottomBar = listOf(
+        Routes.BARCODE_SCANNER,
+        Routes.BOOK_REGISTRATION_METHOD,
+        Routes.BOOK_CONFIRMATION,
+        Routes.PURPOSE_SETTING,
+        Routes.BOOK_DETAIL,
+        Routes.MEMO_ADD,
+        Routes.ACTION_ITEM_CREATE
+    )
+    
+    // 現在のルートがフッターナビゲーションを非表示にする画面かチェック
+    val shouldShowBottomBar = currentDestination?.route?.let { currentRoute ->
+        !routesWithoutBottomBar.any { route ->
+            // パラメータ付きルートの場合は、ベースルートで判定
+            if (route.contains("{")) {
+                currentRoute.startsWith(route.substringBefore("{"))
+            } else {
+                currentRoute == route
+            }
+        }
+    } ?: true
 
     Scaffold(
         modifier = Modifier.fillMaxSize(),
         bottomBar = {
-            NavigationBar {
-                bottomNavItems.forEach { item ->
-                    NavigationBarItem(
-                        icon = { Icon(item.icon, contentDescription = item.label) },
-                        label = { Text(item.label) },
-                        selected = currentDestination?.hierarchy?.any { it.route == item.route } == true,
-                        onClick = {
-                            navController.navigate(item.route) {
-                                popUpTo(navController.graph.findStartDestination().id) {
-                                    saveState = true
+            if (shouldShowBottomBar) {
+                NavigationBar {
+                    bottomNavItems.forEach { item ->
+                        NavigationBarItem(
+                            icon = { Icon(item.icon, contentDescription = item.label) },
+                            label = { Text(item.label) },
+                            selected = currentDestination?.hierarchy?.any { it.route == item.route } == true,
+                            onClick = {
+                                navController.navigate(item.route) {
+                                    popUpTo(navController.graph.findStartDestination().id) {
+                                        saveState = true
+                                    }
+                                    launchSingleTop = true
+                                    restoreState = true
                                 }
-                                launchSingleTop = true
-                                restoreState = true
                             }
-                        }
-                    )
+                        )
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/example/readingtracker/ui/screens/bookregistration/BarcodeScannerScreen.kt
+++ b/app/src/main/java/com/example/readingtracker/ui/screens/bookregistration/BarcodeScannerScreen.kt
@@ -7,6 +7,8 @@ import androidx.camera.view.PreviewView
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -139,6 +141,20 @@ private fun BarcodeScannerContent(
                 .fillMaxSize()
                 .background(Color.Black.copy(alpha = 0.3f))
         ) {
+            // 左上の戻るボタン
+            IconButton(
+                onClick = { navController.popBackStack() },
+                modifier = Modifier
+                    .align(Alignment.TopStart)
+                    .padding(16.dp)
+            ) {
+                Icon(
+                    imageVector = Icons.Default.ArrowBack,
+                    contentDescription = "戻る",
+                    tint = Color.White
+                )
+            }
+            
             Box(
                 modifier = Modifier
                     .size(250.dp)


### PR DESCRIPTION
  実装内容: カメラ起動時のフッターナビゲーション非表示機能

  主な変更点

  1. ReadingTrackerApp.kt:
    - フッターナビゲーションを非表示にする画面のリストを定義
    - 現在のルートに基づいてフッターナビゲーションの表示/非表示を制御
    - パラメータ付きルートにも対応した判定ロジックを実装
  2. BarcodeScannerScreen.kt:
    - カメラ画面に戻るボタンを追加（左上）
    - フッターナビゲーションが非表示の際のナビゲーション手段を提供

  技術的な実装

  - shouldShowBottomBar ロジックでルートベースの表示制御
  - routesWithoutBottomBar リストで非表示対象画面を管理
  - パラメータ付きルート（{bookId} など）の適切な判定処理
